### PR TITLE
refs #11 コマンドラインオプションで grep オプションが指定された場合の処理を追加する．

### DIFF
--- a/src/main/java/com/github/finder/finder.java
+++ b/src/main/java/com/github/finder/finder.java
@@ -3,6 +3,10 @@ package com.github.finder;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.FileNotFoundException;
 
 public class Finder {
     private Args args;
@@ -29,10 +33,9 @@ public class Finder {
 	if(args.getSize() != null){
             flag &= checkTargetSize(file, args.getSize());
         }
-
-
-
-
+	if(args.getGrep() != null){
+            flag &= checkGrep(file, args.getGrep());
+        }
         return true;
     }
 
@@ -75,6 +78,23 @@ public class Finder {
         return false;
     }
 
+    private boolean checkGrep(File file, String pattern){
+        if(file.isFile()){
+            try(BufferedReader in = new BufferedReader(new FileReader(file))){
+		    String line;
+		    while((line = in.readLine()) != null){
+			if(line.indexOf(pattern) >= 0){
+			    return true;
+			}
+		    }
+		}
+	    catch(IOException e){
+		System.out.println(e);
+	    } 
+        }
+        return false;
+    }
+    
     private void traverse(List<String> list, File dir){
         if(isTarget(dir)){
             list.add(dir.getPath());


### PR DESCRIPTION
grepオプションは，ファイルの中身を検索し，指定された文字列が含まれたファイルであれば結果に含めるものとする．
ファイルはテキストファイルであると決め打ちで読むこととする．
検査対象がディレクトリの場合は，常に false を返す．
